### PR TITLE
Set the nixos-test feature on the builder machine config

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -186,7 +186,7 @@
         hostName = sshHost;
         maxJobs = cores;
         protocol = "ssh-ng";
-        supportedFeatures = [ "benchmark" "big-parallel" "kvm" ];
+        supportedFeatures = [ "benchmark" "big-parallel" "kvm" "nixos-test" ];
         systems = [ linuxSystem "x86_64-linux" ];
       }];
 


### PR DESCRIPTION
This allows the rosetta builder to be used for nixos tests, which is really convenient!

(I am currently running a nixos test on my mac, and it keeps being really nice. Hope you will consider this!)

Fixes #8 