### PR TITLE
Additional module options for enhanced control over VM configuration.

### DIFF
--- a/constants.nix
+++ b/constants.nix
@@ -8,6 +8,4 @@ rec {
   sshHostPublicKeyFileName = "${sshHostPrivateKeyFileName}.pub";
   sshUserPrivateKeyFileName = "ssh_user_${sshKeyType}_key";
   sshUserPublicKeyFileName = "${sshUserPrivateKeyFileName}.pub";
-
-  # debug = false; # enable root access in VM and debug logging
 }

--- a/constants.nix
+++ b/constants.nix
@@ -9,5 +9,5 @@ rec {
   sshUserPrivateKeyFileName = "ssh_user_${sshKeyType}_key";
   sshUserPublicKeyFileName = "${sshUserPrivateKeyFileName}.pub";
 
-  debug = false; # enable root access in VM and debug logging
+  # debug = false; # enable root access in VM and debug logging
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixlib": {
       "locked": {
-        "lastModified": 1733620091,
-        "narHash": "sha256-5WoMeCkaXqTZwwCNLRzyLxEJn8ISwjx4cNqLgqKwg9s=",
+        "lastModified": 1736643958,
+        "narHash": "sha256-tmpqTSWVRJVhpvfSN9KXBvKEXplrwKnSZNAoNPf/S/s=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f4dc9a6c02e5e14d91d158522f69f6ab4194eb5b",
+        "rev": "1418bc28a52126761c02dd3d89b2d8ca0f521181",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733706547,
-        "narHash": "sha256-BdFW7TMgES7q8I5FGX5hlz+0Xp4WyfAP3tHDwEupSWU=",
+        "lastModified": 1737057290,
+        "narHash": "sha256-3Pe0yKlCc7EOeq1X/aJVDH0CtNL+tIBm49vpepwL1MQ=",
         "owner": "nix-community",
         "repo": "nixos-generators",
-        "rev": "f5a0197ccfef7388885fc9455e74d6dd39e0c5e8",
+        "rev": "d002ce9b6e7eb467cd1c6bb9aef9c35d191b5453",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733759999,
-        "narHash": "sha256-463SNPWmz46iLzJKRzO3Q2b0Aurff3U1n0nYItxq7jU=",
+        "lastModified": 1737885589,
+        "narHash": "sha256-Zf0hSrtzaM1DEz8//+Xs51k/wdSajticVrATqDrfQjg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a73246e2eef4c6ed172979932bc80e1404ba2d56",
+        "rev": "852ff1d9e153d8875a83602e03fdef8a63f0ecf8",
         "type": "github"
       },
       "original": {

--- a/module.nix
+++ b/module.nix
@@ -229,6 +229,11 @@ with lib; {
           umask 'g-w,o='
           chmod 'g-w,o=' .
 
+          if [[ $(cat ${vmYamlSh}) != $(cat .lima/${vmNameSh}/lima.yaml) ]] ; then
+            limactl stop -f ${vmNameSh}
+            limactl delete -f ${vmNameSh}
+          fi
+
           # must be idempotent in the face of partial failues
           limactl list -q 2>'/dev/null' | grep -q ${vmNameSh} || {
             yes | ssh-keygen \

--- a/package.nix
+++ b/package.nix
@@ -1,196 +1,207 @@
 # dependencies
-{ nixos-generators
-, nixpkgs
-
-# pkgs
-, lib
-, mount
-, umount
-
-# configuration
-, linuxSystem
-, onDemand # enable launchd socket activation
+{
+  nixos-generators,
+  nixpkgs,
+  # pkgs
+  lib,
+  mount,
+  umount,
+  # configuration
+  linuxSystem,
+  debug ? false,
+  extraConfig ? {},
+  onDemand ? false, # enable launchd socket activation
+  withRosetta ? true,
 }:
-nixos-generators.nixosGenerate (
-let
-  inherit (import ./constants.nix)
-    linuxHostName
-    linuxUser
-
-    sshHostPrivateKeyFileName
-    sshUserPublicKeyFileName
-
-    debug
-    ;
-  imageFormat = "qcow-efi"; # must match `vmYaml.images.location`s extension
-
-  sshdKeys = "sshd-keys";
-  sshDirPath = "/etc/ssh";
-  sshHostPrivateKeyFilePath = "${sshDirPath}/${sshHostPrivateKeyFileName}";
-
-in {
-  format = imageFormat;
-
-  modules = [ {
-    boot = {
-      kernelParams = [ "console=tty0" ];
-
-      loader = {
-        efi.canTouchEfiVariables = true;
-        systemd-boot.enable = true;
-      };
-    };
-
-    documentation.enable = false;
-
-    fileSystems = {
-      "/".options = [ "discard" "noatime" ];
-      "/boot".options = [ "discard" "noatime" "umask=0077" ];
-    };
-
-    networking.hostName = linuxHostName;
-
-    nix = {
-      channel.enable = false;
-      registry.nixpkgs.flake = nixpkgs;
-
-      settings = {
-        auto-optimise-store = true;
-        experimental-features = [ "flakes" "nix-command" ];
-        min-free = "5G";
-        max-free = "7G";
-        trusted-users = [ linuxUser ];
-      };
-    };
-
-    security = {
-      sudo = {
-        enable = debug;
-        wheelNeedsPassword = !debug;
-      };
-    };
-
-    services = {
-      getty = lib.optionalAttrs debug { autologinUser = linuxUser; };
-
-      logind = lib.optionalAttrs onDemand {
-        extraConfig = ''
-          IdleAction=poweroff
-          IdleActionSec=3h
-        '';
-      };
-
-      openssh = {
-        enable = true;
-        hostKeys = []; # disable automatic host key generation
-
-        settings = {
-          HostKey = sshHostPrivateKeyFilePath;
-          PasswordAuthentication = false;
-        };
-      };
-    };
-
-    system = {
-      disableInstallerTools = true;
-      stateVersion = "24.05";
-    };
-
-    # macOS' Virtualization framework's virtiofs implementation will grant any guest user access
-    # to mounted files; they always appear to be owned by the effective UID and so access cannot
-    # be restricted.
-    # To protect the guest's SSH host key, the VM is configured to prevent any logins (via
-    # console, SSH, etc) by default.  This service then runs before sshd, mounts virtiofs,
-    # copies the keys to local files (with appropriate ownership and permissions), and unmounts
-    # the filesystem before allowing SSH to start.
-    # Once SSH has been allowed to start (and given the guest user a chance to log in), the
-    # virtiofs must never be mounted again (as the user could have left some process active to
-    # read its secrets).  This is prevented by `unitconfig.ConditionPathExists` below.
-    systemd.services."${sshdKeys}" =
+with lib;
+  nixos-generators.nixosGenerate (
     let
-      # Lima labels its virtiofs folder mounts counting up:
-      # https://github.com/lima-vm/lima/blob/0e931107cadbcb6dbc7bbb25626f66cdbca1f040/pkg/vz/vm_darwin.go#L568
-      # So this suffix must match `vmYaml.mounts.location`s order:
-      sshdKeysVirtiofsTag = "mount0";
+      inherit
+        (import ./constants.nix)
+        linuxHostName
+        linuxUser
+        sshHostPrivateKeyFileName
+        sshUserPublicKeyFileName
+        ;
+      imageFormat = "qcow-efi"; # must match `vmYaml.images.location`s extension
 
-      sshdKeysDirPath = "/var/${sshdKeys}";
-      sshAuthorizedKeysUserFilePath = "${sshDirPath}/authorized_keys.d/${linuxUser}";
-      sshdService = "sshd.service";
-
+      sshdKeys = "sshd-keys";
+      sshDirPath = "/etc/ssh";
+      sshHostPrivateKeyFilePath = "${sshDirPath}/${sshHostPrivateKeyFileName}";
     in {
-      before = [ sshdService ];
-      description = "Install sshd's host and authorized keys";
-      enableStrictShellChecks = true;
-      path = [ mount umount ];
-      requiredBy = [ sshdService ];
+      format = imageFormat;
+      modules =
+        [
+          {
+            boot = {
+              kernelParams = ["console=tty0"];
 
-      script =
-      let
-        sshAuthorizedKeysUserFilePathSh = lib.escapeShellArg sshAuthorizedKeysUserFilePath;
-        sshAuthorizedKeysUserTmpFilePathSh =
-          lib.escapeShellArg "${sshAuthorizedKeysUserFilePath}.tmp";
-        sshHostPrivateKeyFileNameSh = lib.escapeShellArg sshHostPrivateKeyFileName;
-        sshHostPrivateKeyFilePathSh = lib.escapeShellArg sshHostPrivateKeyFilePath;
-        sshUserPublicKeyFileNameSh = lib.escapeShellArg sshUserPublicKeyFileName;
-        sshdKeysDirPathSh = lib.escapeShellArg sshdKeysDirPath;
-        sshdKeysVirtiofsTagSh = lib.escapeShellArg sshdKeysVirtiofsTag;
+              loader = {
+                efi.canTouchEfiVariables = true;
+                systemd-boot.enable = true;
+              };
+            };
 
-      in ''
-        # must be idempotent in the face of partial failues
+            documentation.enable = false;
 
-        mkdir -p ${sshdKeysDirPathSh}
-        mount \
-          -t 'virtiofs' \
-          -o 'nodev,noexec,nosuid,ro' \
-          ${sshdKeysVirtiofsTagSh} \
-          ${sshdKeysDirPathSh}
+            fileSystems = {
+              "/".options = [
+                "discard"
+                "noatime"
+              ];
+              "/boot".options = [
+                "discard"
+                "noatime"
+                "umask=0077"
+              ];
+            };
 
-        mkdir -p "$(dirname ${sshHostPrivateKeyFilePathSh})"
-        (
-          umask 'go='
-          cp ${sshdKeysDirPathSh}/${sshHostPrivateKeyFileNameSh} ${sshHostPrivateKeyFilePathSh}
-        )
+            networking.hostName = linuxHostName;
 
-        mkdir -p "$(dirname ${sshAuthorizedKeysUserTmpFilePathSh})"
-        cp \
-          ${sshdKeysDirPathSh}/${sshUserPublicKeyFileNameSh} \
-          ${sshAuthorizedKeysUserTmpFilePathSh}
-        chmod 'a+r' ${sshAuthorizedKeysUserTmpFilePathSh}
+            nix = {
+              channel.enable = false;
+              registry.nixpkgs.flake = nixpkgs;
 
-        umount ${sshdKeysDirPathSh}
-        rmdir ${sshdKeysDirPathSh}
+              settings = {
+                auto-optimise-store = true;
+                experimental-features = [
+                  "flakes"
+                  "nix-command"
+                ];
+                min-free = "5G";
+                max-free = "7G";
+                trusted-users = [linuxUser];
+              };
+            };
 
-        # must be last so only now `unitConfig.ConditionPathExists` triggers
-        mv ${sshAuthorizedKeysUserTmpFilePathSh} ${sshAuthorizedKeysUserFilePathSh}
-      '';
+            security = {
+              sudo = {
+                enable = debug;
+                wheelNeedsPassword = !debug;
+              };
+            };
 
-      serviceConfig.Type = "oneshot";
+            services = {
+              getty = optionalAttrs debug {autologinUser = linuxUser;};
 
-      # see comments on this service and in its `script`
-      unitConfig.ConditionPathExists = "!${sshAuthorizedKeysUserFilePath}";
-    };
+              logind = optionalAttrs onDemand {
+                extraConfig = ''
+                  IdleAction=poweroff
+                  IdleActionSec=3h
+                '';
+              };
 
-    users = {
-      # console and (initial) SSH logins are purposely disabled
-      # see: `systemd.services."${sshdKeys}"`
-      allowNoPasswordLogin = true;
+              openssh = {
+                enable = true;
+                hostKeys = []; # disable automatic host key generation
 
-      mutableUsers = false;
+                settings = {
+                  HostKey = sshHostPrivateKeyFilePath;
+                  PasswordAuthentication = false;
+                };
+              };
+            };
 
-      users."${linuxUser}" = {
-        isNormalUser = true;
-        extraGroups = lib.optionals debug [ "wheel" ];
-      };
-    };
+            system = {
+              disableInstallerTools = true;
+              stateVersion = "24.05";
+            };
 
-    virtualisation.rosetta = {
-      enable = true;
+            # macOS' Virtualization framework's virtiofs implementation will grant any guest user access
+            # to mounted files; they always appear to be owned by the effective UID and so access cannot
+            # be restricted.
+            # To protect the guest's SSH host key, the VM is configured to prevent any logins (via
+            # console, SSH, etc) by default.  This service then runs before sshd, mounts virtiofs,
+            # copies the keys to local files (with appropriate ownership and permissions), and unmounts
+            # the filesystem before allowing SSH to start.
+            # Once SSH has been allowed to start (and given the guest user a chance to log in), the
+            # virtiofs must never be mounted again (as the user could have left some process active to
+            # read its secrets).  This is prevented by `unitconfig.ConditionPathExists` below.
+            systemd.services."${sshdKeys}" = let
+              # Lima labels its virtiofs folder mounts counting up:
+              # https://github.com/lima-vm/lima/blob/0e931107cadbcb6dbc7bbb25626f66cdbca1f040/pkg/vz/vm_darwin.go#L568
+              # So this suffix must match `vmYaml.mounts.location`s order:
+              sshdKeysVirtiofsTag = "mount0";
 
-      # Lima's virtiofs label for rosetta:
-      # https://github.com/lima-vm/lima/blob/0e931107cadbcb6dbc7bbb25626f66cdbca1f040/pkg/vz/rosetta_directory_share_arm64.go#L15
-      mountTag = "vz-rosetta";
-    };
-  } ];
+              sshdKeysDirPath = "/var/${sshdKeys}";
+              sshAuthorizedKeysUserFilePath = "${sshDirPath}/authorized_keys.d/${linuxUser}";
+              sshdService = "sshd.service";
+            in {
+              before = [sshdService];
+              description = "Install sshd's host and authorized keys";
+              enableStrictShellChecks = true;
+              path = [
+                mount
+                umount
+              ];
+              requiredBy = [sshdService];
 
-  system = linuxSystem;
-})
+              script = let
+                sshAuthorizedKeysUserFilePathSh = escapeShellArg sshAuthorizedKeysUserFilePath;
+                sshAuthorizedKeysUserTmpFilePathSh = escapeShellArg "${sshAuthorizedKeysUserFilePath}.tmp";
+                sshHostPrivateKeyFileNameSh = escapeShellArg sshHostPrivateKeyFileName;
+                sshHostPrivateKeyFilePathSh = escapeShellArg sshHostPrivateKeyFilePath;
+                sshUserPublicKeyFileNameSh = escapeShellArg sshUserPublicKeyFileName;
+                sshdKeysDirPathSh = escapeShellArg sshdKeysDirPath;
+                sshdKeysVirtiofsTagSh = escapeShellArg sshdKeysVirtiofsTag;
+              in ''
+                # must be idempotent in the face of partial failues
+
+                mkdir -p ${sshdKeysDirPathSh}
+                mount \
+                  -t 'virtiofs' \
+                  -o 'nodev,noexec,nosuid,ro' \
+                  ${sshdKeysVirtiofsTagSh} \
+                  ${sshdKeysDirPathSh}
+
+                mkdir -p "$(dirname ${sshHostPrivateKeyFilePathSh})"
+                (
+                  umask 'go='
+                  cp ${sshdKeysDirPathSh}/${sshHostPrivateKeyFileNameSh} ${sshHostPrivateKeyFilePathSh}
+                )
+
+                mkdir -p "$(dirname ${sshAuthorizedKeysUserTmpFilePathSh})"
+                cp \
+                  ${sshdKeysDirPathSh}/${sshUserPublicKeyFileNameSh} \
+                  ${sshAuthorizedKeysUserTmpFilePathSh}
+                chmod 'a+r' ${sshAuthorizedKeysUserTmpFilePathSh}
+
+                umount ${sshdKeysDirPathSh}
+                rmdir ${sshdKeysDirPathSh}
+
+                # must be last so only now `unitConfig.ConditionPathExists` triggers
+                mv ${sshAuthorizedKeysUserTmpFilePathSh} ${sshAuthorizedKeysUserFilePathSh}
+              '';
+
+              serviceConfig.Type = "oneshot";
+
+              # see comments on this service and in its `script`
+              unitConfig.ConditionPathExists = "!${sshAuthorizedKeysUserFilePath}";
+            };
+
+            users = {
+              # console and (initial) SSH logins are purposely disabled
+              # see: `systemd.services."${sshdKeys}"`
+              allowNoPasswordLogin = true;
+
+              mutableUsers = false;
+
+              users."${linuxUser}" = {
+                isNormalUser = true;
+                extraGroups = optionals debug ["wheel"];
+              };
+            };
+
+            virtualisation.rosetta = optionalAttrs withRosetta {
+              enable = true;
+
+              # Lima's virtiofs label for rosetta:
+              # https://github.com/lima-vm/lima/blob/0e931107cadbcb6dbc7bbb25626f66cdbca1f040/pkg/vz/rosetta_directory_share_arm64.go#L15
+              mountTag = "vz-rosetta";
+            };
+          }
+        ]
+        ++ [extraConfig];
+      system = linuxSystem;
+    }
+  )


### PR DESCRIPTION
This pull request includes several changes to enhance the configurability and modularity of the VM. The most significant changes include additional options for `config.rosetta-builder`, refactoring the package outputs in `flake.nix`, and updating `package.nix` to support the additional options implemented in `module.nix`.

### New module options:

- `cores`: specifies number of cpu cores for the Lima instance, as well as the maximum number of jobs allowed for the builder in the `config.nix.buildMachines` specification. Default is `8`.
- `diskSize`: specifies the size of the disk created for the instance, default is `"100GiB"`.
- `memory`: specifies the amount of memory to allocate, default is `"6GiB"`.
- `enableRosetta`: enable/disable Rosetta 2 for the VM, `true` by default. I'd like to hear your thoughts on this one as it sort of contradicts the idea of this project (and the name), but I thought it might be beneficial to provide the option to disable it if it's not needed by the user, as running Rosetta 2 causes a slight performance decrease for the VM ([lima-vm/lima#1269](https://github.com/lima-vm/lima/issues/1269#issuecomment-1368946809)).
- `port`: specify SSH port for the instance, default is `31122`.

### Major changes:

* `flake.nix`: Removed `packages.aarch64-linux.on-demand`, since `onDemand` is passed as an override directly to the derivation that builds the image, so having an explicit output for each is unnecessary.
* `module.nix`: Added `imageWithFinalConfig` which calls `packages.aarch64-linux.image`, passing the values of the options set in the module as overrides. The `vmYaml` function now sets the values of `disk`, `memory`, `cpus`, `ssh.localPort` and `rosetta.enabled` to that of their respective module option instead of being hard-coded. The script for the launchd daemon has also been modified so that changes to the values of any module options that set parameter values in `vmYaml` will cause the existing Lima instance to be deleted and a new one will be created using the updated `vmYaml`.

### Minor changes:

* `package.nix`: Improved the readability of the configuration by using `with lib` and restructuring the code blocks.
*  `flake.lock`: Updated flake inputs.
*  `constants.nix`: remove `debug` as it is now defined by `config.rosetta-builder.debug`.