### PR TITLE
flake.nix: add formatter flake attribute, format nix files with nixfmt-rfc-style

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,36 +9,44 @@
     };
   };
 
-  outputs = {
-    self,
-    nixos-generators,
-    nixpkgs,
-  }: let
-    darwinSystem = "aarch64-darwin";
-    linuxSystem = builtins.replaceStrings ["darwin"] ["linux"] darwinSystem;
-  in {
-    packages."${linuxSystem}" = let
-      pkgs = nixpkgs.legacyPackages."${linuxSystem}";
-    in rec {
-      default = image;
-
-      image = pkgs.callPackage ./package.nix {
-        inherit linuxSystem nixos-generators nixpkgs;
-        # Optional: override default argument values passed to the derivation.
-        # Many can also be accessed through the module.
-      };
-    };
-
-    devShells."${darwinSystem}".default = let
-      pkgs = nixpkgs.legacyPackages."${darwinSystem}";
+  outputs =
+    {
+      self,
+      nixos-generators,
+      nixpkgs,
+    }:
+    let
+      darwinSystem = "aarch64-darwin";
+      linuxSystem = builtins.replaceStrings [ "darwin" ] [ "linux" ] darwinSystem;
     in
-      pkgs.mkShell {
-        packages = [pkgs.lima];
+    {
+      packages."${linuxSystem}" =
+        let
+          pkgs = nixpkgs.legacyPackages."${linuxSystem}";
+        in
+        rec {
+          default = image;
+
+          image = pkgs.callPackage ./package.nix {
+            inherit linuxSystem nixos-generators nixpkgs;
+            # Optional: override default argument values passed to the derivation.
+            # Many can also be accessed through the module.
+          };
+        };
+
+      devShells."${darwinSystem}".default =
+        let
+          pkgs = nixpkgs.legacyPackages."${darwinSystem}";
+        in
+        pkgs.mkShell {
+          packages = [ pkgs.lima ];
+        };
+
+      darwinModules.default = import ./module.nix {
+        inherit linuxSystem;
+        image = self.packages."${linuxSystem}".image;
       };
 
-    darwinModules.default = import ./module.nix {
-      inherit linuxSystem;
-      image = self.packages."${linuxSystem}".image;
+      formatter."${darwinSystem}" = nixpkgs.legacyPackages."${darwinSystem}".nixfmt-rfc-style;
     };
-  };
 }


### PR DESCRIPTION
## Changes
- Added `formatter.aarch64-darwin` attribute to flake outputs using `nixfmt-rfc-style` as the formatter, which enables the use of the `nix fmt` command.
- Formatted nix files with `nixfmt-rfc-style`.