### PR TITLE
Make linger time configurable.

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -70,6 +70,17 @@ in
       '';
     };
 
+    onDemandLingerTime = mkOption {
+      type = types.str;
+      default = "3h";
+      description = ''
+        If onDemand=true, this specifies the number of seconds of inactivity before the VM will
+        power itself off.
+
+        Accepts Systemd time format. Must be in the format described in {manpage}`systemd.time(7)`.
+      '';
+    };
+
     port = mkOption {
       type = types.int;
 
@@ -102,6 +113,7 @@ in
       imageWithFinalConfig = image.override {
         inherit debugInsecurely;
         onDemand = cfg.onDemand;
+        onDemandLingerTime = cfg.onDemandLingerTime;
       };
 
       cfg = config.nix-rosetta-builder;

--- a/package.nix
+++ b/package.nix
@@ -11,6 +11,7 @@
   debugInsecurely ? false, # enable auto-login and passwordless sudo to root
   extraConfig ? { },
   onDemand ? false, # enable launchd socket activation
+  onDemandLingerTime ? "3h", # poweroff after 3 hours of inactivity
   withRosetta ? true,
 }:
 nixos-generators.nixosGenerate (
@@ -90,7 +91,7 @@ nixos-generators.nixosGenerate (
           logind = optionalAttrs onDemand {
             extraConfig = ''
               IdleAction=poweroff
-              IdleActionSec=3h
+              IdleActionSec=${onDemandLingerTime}
             '';
           };
 


### PR DESCRIPTION
This introduces a new option `onDemandLingerTime`. This works, but I could also see an argument for

```nix
onDemand.enable = true;
onDemand.lingerTime = "3h";
```

What do you think?