### PR TITLE
ssh: Ask for host fingerprint confirmation on first login attempt

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -191,7 +191,6 @@ in
           Hostname localhost
           HostKeyAlias "${sshHostKeyAlias}"
           Port "${toString cfg.port}"
-          StrictHostKeyChecking yes
           User "${linuxUser}"
           IdentityFile "${workingDirPath}/${sshUserPrivateKeyFileName}"
       '';


### PR DESCRIPTION
Strict host checking means that the user will have to pre-register the host fingerprint in their known_hosts file. If they don't, login attempt will fail with:

No ED25519 host key is known for rosetta-builder-key and you have requested strict checking. Host key verification failed.

This can be worked around by executing on first login:

$ ssh -o StrictHostKeyChecking=false rosetta-builder

...but it's more user friendly to let the user confirm the fingerprint interactively.

Related-To: #18