### PR TITLE
Create /etc/hosts if not existent

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -382,6 +382,12 @@ in
           printf >&2 'setting up working directory %s...\n' ${workingDirPathSh}
           mkdir -p ${workingDirPathSh}
           chown ${userSh}:${groupSh} ${workingDirPathSh}
+
+          # VM startup will fail if /etc/hosts does not exist.
+          if [ ! -f /etc/hosts ]; then
+            touch /etc/hosts
+            chmod 0644 /etc/hosts
+          fi
         '';
     };
 }


### PR DESCRIPTION
VM startup will fail if '/etc/hosts' does not exist.

Up until trying to start everything works but than this error is shown:

```bash
❯ limactl start  --foreground rosetta-builder-vm
INFO[0000] Using the existing instance "rosetta-builder-vm"
INFO[0000] Starting the instance "rosetta-builder-vm" with VM driver "vz"
INFO[0000] Running the host agent in the foreground
{"level":"debug","msg":"ResolveVMType: resolved VMType \"vz\" (existing instance, with \"/Users/oliver.wiegers/.lima/rosetta-builder-vm/vz-identifier\")","time":"2025-03-10T07:07:47+01:00"}
{"level":"debug","msg":"Creating iso file /Users/oliver.wiegers/.lima/rosetta-builder-vm/cidata.iso","time":"2025-03-10T07:07:48+01:00"}
{"level":"debug","msg":"Using /var/folders/p_/_t2_qt755974fjg43mttbz6w0000gn/T/diskfs_iso1327180885 as workspace","time":"2025-03-10T07:07:48+01:00"}
{"level":"debug","msg":"Failed to detect CPU features. Assuming that AES acceleration is available on this Apple silicon.","time":"2025-03-10T07:07:48+01:00"}
{"level":"debug","msg":"OpenSSH version 9.8.1 detected","time":"2025-03-10T07:07:48+01:00"}
{"level":"debug","msg":"AES accelerator seems available, prioritizing aes128-gcm@openssh.com and aes256-gcm@openssh.com","time":"2025-03-10T07:07:48+01:00"}
{"level":"info","msg":"hostagent socket created at /Users/oliver.wiegers/.lima/rosetta-builder-vm/ha.sock","time":"2025-03-10T07:07:48+01:00"}
{"level":"info","msg":"Starting VZ (hint: to watch the boot progress, see \"/Users/oliver.wiegers/.lima/rosetta-builder-vm/serial*.log\")","time":"2025-03-10T07:07:48+01:00"}
{"level":"debug","msg":"Start udp DNS listening on: 127.0.0.1:54615","time":"2025-03-10T07:07:48+01:00"}
{"level":"debug","msg":"Using search domains: [oliverwiegers.de oliverwiegers.net]","time":"2025-03-10T07:07:48+01:00"}
{"level":"debug","msg":"Start tcp DNS listening on: 127.0.0.1:56519","time":"2025-03-10T07:07:48+01:00"}
{"time":"2025-03-10T07:07:48.10548+01:00","status":{"exiting":true}}
{"level":"fatal","msg":"cannot add network services: open /etc/hosts: no such file or directory","time":"2025-03-10T07:07:48+01:00"}

❯ cat /etc/hosts
[bat error]: '/etc/hosts': No such file or directory (os error 2)
```