### PR TITLE
module: add speedFactor and sshProtocol

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -45,6 +45,16 @@ in
       '';
     };
 
+    speedFactor = mkOption {
+      type = types.int;
+      default = 1;
+      description = ''
+        The relative speed factor of the builder.
+        This sets the speed factor in the `nix.buildMachines` specification,
+        which affects how Nix distributes build tasks to this machine.
+      '';
+    };
+
     cores = mkOption {
       type = types.int;
       default = 8;
@@ -376,6 +386,7 @@ in
         nix = {
           buildMachines = [
             {
+              inherit (cfg) speedFactor;
               hostName = sshHost;
               maxJobs = cfg.cores;
               protocol = "ssh-ng";

--- a/module.nix
+++ b/module.nix
@@ -129,6 +129,18 @@ in
         The SSH port used by the VM.
       '';
     };
+
+    sshProtocol = mkOption {
+      type = types.enum [
+        "ssh"
+        "ssh-ng"
+      ];
+      default = "ssh-ng";
+      description = ''
+        The SSH protocol to use for remote builds.
+        Options are "ssh" (legacy) or "ssh-ng" (newer protocol with better performance).
+      '';
+    };
   };
 
   config =
@@ -389,7 +401,7 @@ in
               inherit (cfg) speedFactor;
               hostName = sshHost;
               maxJobs = cfg.cores;
-              protocol = "ssh-ng";
+              protocol = cfg.sshProtocol;
               supportedFeatures = [
                 "benchmark"
                 "big-parallel"


### PR DESCRIPTION
This allows configuring the relative speed factor in nix.buildMachines for the rosetta-builder, affecting how Nix distributes build tasks when multiple build machines are available.

I want to make nix-rosetta-builder a higher priority than connecting out to my remote shared build resources. 

Also added a sshProtocol option for users to have flexibility. I seem to have issues with `ssh-ng` and need to use `ssh` to make things work for remote building. 