### PR TITLE
image: migrate off of nixos-generators

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,48 +1,12 @@
 {
   "nodes": {
-    "nixlib": {
-      "locked": {
-        "lastModified": 1736643958,
-        "narHash": "sha256-tmpqTSWVRJVhpvfSN9KXBvKEXplrwKnSZNAoNPf/S/s=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "1418bc28a52126761c02dd3d89b2d8ca0f521181",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixos-generators": {
-      "inputs": {
-        "nixlib": "nixlib",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1737057290,
-        "narHash": "sha256-3Pe0yKlCc7EOeq1X/aJVDH0CtNL+tIBm49vpepwL1MQ=",
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "rev": "d002ce9b6e7eb467cd1c6bb9aef9c35d191b5453",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737885589,
-        "narHash": "sha256-Zf0hSrtzaM1DEz8//+Xs51k/wdSajticVrATqDrfQjg=",
+        "lastModified": 1746904237,
+        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "852ff1d9e153d8875a83602e03fdef8a63f0ecf8",
+        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
         "type": "github"
       },
       "original": {
@@ -54,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "nixos-generators": "nixos-generators",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,18 +3,10 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixos-generators = {
-      url = "github:nix-community/nixos-generators";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =
-    {
-      self,
-      nixos-generators,
-      nixpkgs,
-    }:
+    { self, nixpkgs }:
     let
       darwinSystem = "aarch64-darwin";
       linuxSystem = builtins.replaceStrings [ "darwin" ] [ "linux" ] darwinSystem;
@@ -28,7 +20,7 @@
           default = image;
 
           image = pkgs.callPackage ./package.nix {
-            inherit linuxSystem nixos-generators nixpkgs;
+            inherit linuxSystem nixpkgs;
             # Optional: override default argument values passed to the derivation.
             # Many can also be accessed through the module.
           };

--- a/module.nix
+++ b/module.nix
@@ -189,7 +189,7 @@ in
         images = [
           {
             # extension must match `imageFormat`
-            location = "${imageWithFinalConfig}/nixos.qcow2";
+            location = "${imageWithFinalConfig}/${imageWithFinalConfig.passthru.filePath}";
           }
         ];
 

--- a/package.nix
+++ b/package.nix
@@ -1,6 +1,4 @@
 {
-  # dependencies
-  nixos-generators,
   nixpkgs,
   # pkgs
   lib,
@@ -14,23 +12,22 @@
   onDemandLingerMinutes ? 180, # poweroff after 3 hours of inactivity
   withRosetta ? true,
 }:
-nixos-generators.nixosGenerate (
-  let
-    inherit (lib) escapeShellArg optionalAttrs optionals;
-    inherit (import ./constants.nix)
-      linuxHostName
-      linuxUser
-      sshHostPrivateKeyFileName
-      sshUserPublicKeyFileName
-      ;
-    imageFormat = "qcow-efi"; # must match `vmYaml.images.location`s extension
 
-    sshdKeys = "sshd-keys";
-    sshDirPath = "/etc/ssh";
-    sshHostPrivateKeyFilePath = "${sshDirPath}/${sshHostPrivateKeyFileName}";
-  in
-  {
-    format = imageFormat;
+let
+  inherit (lib) escapeShellArg optionalAttrs optionals;
+  inherit (import ./constants.nix)
+    linuxHostName
+    linuxUser
+    sshHostPrivateKeyFileName
+    sshUserPublicKeyFileName
+    ;
+
+  sshdKeys = "sshd-keys";
+  sshDirPath = "/etc/ssh";
+  sshHostPrivateKeyFilePath = "${sshDirPath}/${sshHostPrivateKeyFileName}";
+
+  imageConfig = nixpkgs.lib.nixosSystem {
+    system = linuxSystem;
     modules = [
       {
         boot = {
@@ -205,6 +202,6 @@ nixos-generators.nixosGenerate (
         };
       }
     ] ++ [ potentiallyInsecureExtraNixosModule ];
-    system = linuxSystem;
-  }
-)
+  };
+in
+imageConfig.config.system.build.images.qemu-efi


### PR DESCRIPTION
This pull request removes the `nixos-generators` flake input and refactors the code to directly use the `config.system.build.images.qemu-efi` module that is built-in to the NixOS configuration instead of relying on `nixes-generators.nixosGenerate`. This change simplifies the image configuration and eliminates the need for any external flake inputs besides `nixpkgs`.

### Removal of `nixos-generators`:
* [`flake.nix, flake.lock`](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L6-R9): Removed `nixos-generators` from inputs and updated lock file. [[1]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L6-R9)
* [`package.nix`](diffhunk://#diff-16cddcd6b987528aee0e3d6930f04e9413e1e349c66d385fdc93290af456800dL2-L3): Removed the call to `nixos-generators.nixosGenerate` and instead call `nixpkgs.lib.nixosSystem` under an attribute set named `imageConfig`. [[1]](diffhunk://#diff-16cddcd6b987528aee0e3d6930f04e9413e1e349c66d385fdc93290af456800dL2-L3) [[2]](diffhunk://#diff-16cddcd6b987528aee0e3d6930f04e9413e1e349c66d385fdc93290af456800dL17-R15) [[3]](diffhunk://#diff-16cddcd6b987528aee0e3d6930f04e9413e1e349c66d385fdc93290af456800dL26-R30) [[4]](diffhunk://#diff-16cddcd6b987528aee0e3d6930f04e9413e1e349c66d385fdc93290af456800dL208-R207)

### Image Path Adjustment:
* [`module.nix`](diffhunk://#diff-d08d64ddbf5f8a384c8213d871167c6f55002970d7312c302b4bd441fafb5e8dL192-R192): Updated the image location path in `vmYaml` to use `imageWithFinalConfig.passthru.filePath` instead of the hardcoded `nixos.qcow2`, as the filename of the image built using the `images` module is much longer and will change since it includes the `nixpkgs` version.

I've tested this configuration in my own nix-darwin config and have had no issues rebuilding the image and running the vm with the exact same module configuration as before.